### PR TITLE
Assign cap code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.temple.cla.papolicy.wolfgang</groupId>
     <artifactId>newppdpapp</artifactId>
-    <version>1.1.14-SNAPSHOT</version>
+    <version>1.2.0-CAPCODE</version>
     <packaging>war</packaging>
 
     <name>newppdpapp</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>edu.temple.cla.papolicy.wolfgang</groupId>
     <artifactId>newppdpapp</artifactId>
-    <version>1.1.13-SNAPSHOT</version>
+    <version>1.1.14-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>newppdpapp</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
             <id>UploadTranscriptData-mvn-repo</id>
             <url>https://raw.github.com/pwolfgang/UploadTranscriptData/mvn-repo</url>
         </repository>
+        <repository>
+            <id>querybuilder</id>
+            <url>https://raw.github.com/pwolfgang/querybuilder/mvn-repo</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -37,6 +41,11 @@
             <groupId>edu.temple.cla.policydb</groupId>
             <artifactId>uploadtranscriptdata</artifactId>
             <version>1.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>querybuilder</artifactId>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat</groupId>

--- a/src/main/java/edu/temple/cla/papolicy/wolfgang/resolveclusters/Util.java
+++ b/src/main/java/edu/temple/cla/papolicy/wolfgang/resolveclusters/Util.java
@@ -108,6 +108,7 @@ public class Util {
     }
 
     public static String reformatHyperlink(String hyperlink) {
+        if (hyperlink == null) return "";
         int firstSharp = hyperlink.indexOf("#");
         if (firstSharp == -1) {
             return hyperlink;

--- a/src/main/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCode.java
+++ b/src/main/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCode.java
@@ -29,7 +29,7 @@ public class AssignCAPCode {
         try (Session sess = sessionFactory.openSession()) {
             Transaction tx = sess.beginTransaction();
             // Initially set CAPCode to Code
-            String setDefaultTemplate = "update %s set CAPCode=%s";
+            String setDefaultTemplate = "update %s set CAPCode=%s CAPOk=1";
             String setDefaultQuery = String.format(setDefaultTemplate, 
                     table.getTableName(), table.getCodeColumn());
             sess.createNativeQuery(setDefaultQuery)

--- a/src/main/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCode.java
+++ b/src/main/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCode.java
@@ -1,0 +1,63 @@
+package edu.temple.cla.policydb.capcodeassignment;
+
+import edu.temple.cla.policydb.ppdpapp.api.tables.Table;
+import edu.temple.cla.policydb.queryBuilder.Comparison;
+import edu.temple.cla.policydb.queryBuilder.FreeTextParser;
+import edu.temple.cla.policydb.queryBuilder.QueryBuilder;
+import edu.temple.cla.policydb.queryBuilder.SetClause;
+import javax.sql.DataSource;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class AssignCAPCode {
+    
+    private SessionFactory sessionFactory;
+    private DataSource datasource;
+    
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    public void setDataSource(DataSource datasource) {
+        this.datasource = datasource;
+    }
+    
+    public ResponseEntity<?> doAssignment(Table table) {
+        try (Session sess = sessionFactory.openSession()) {
+            Transaction tx = sess.beginTransaction();
+            // Initially set CAPCode to Code
+            String setDefaultTemplate = "update %s set CAPCode=%s";
+            String setDefaultQuery = String.format(setDefaultTemplate, 
+                    table.getTableName(), table.getCodeColumn());
+            sess.createNativeQuery(setDefaultQuery)
+                    .executeUpdate();
+            for (Criteria criteria: Criteria.getCriteria()) {
+                String query = createQuery(criteria, table);
+                sess.createNativeQuery(query)
+                    .executeUpdate();
+            }
+            tx.commit();
+        }
+        return new ResponseEntity<>("Updated " + table.getTableName(), HttpStatus.OK);
+    }
+    
+    static String createQuery(Criteria criteria, Table table) {     
+        QueryBuilder queryBuilder = new QueryBuilder();
+        queryBuilder.setTable(table.getTableName());
+        queryBuilder.addSetClause(new SetClause("CAPCode", criteria.getNewCAPCode()));
+        queryBuilder.addSetClause(new SetClause("CAPOk", 0));
+        queryBuilder.addToSelectCriteria(new Comparison(table.getCodeColumn(), 
+                "=", Integer.toString(criteria.getCurrentCode())));
+        queryBuilder.addToSelectCriteria(FreeTextParser.parse(table.getTextColumn(), 
+                criteria.getKeyWords()));
+        String filter = criteria.getFilter();
+        if (filter != null && !filter.isEmpty() ) {
+            queryBuilder.addFilter(new Comparison(filter, "<>", "0"));
+        }
+        return queryBuilder.buildUpdate();
+    }
+
+}

--- a/src/main/java/edu/temple/cla/policydb/capcodeassignment/Criteria.java
+++ b/src/main/java/edu/temple/cla/policydb/capcodeassignment/Criteria.java
@@ -1,0 +1,107 @@
+package edu.temple.cla.policydb.capcodeassignment;
+
+public class Criteria {
+
+    /**
+     * @return the CRITERIA
+     */
+    public static Criteria[] getCriteria() {
+        return CRITERIA;
+    }
+    
+    public static Criteria getCriteriaByIndex(int i) {
+        return CRITERIA[i];
+    }
+    
+    public static Criteria getCriteriaByTitle(String title) {
+        for (Criteria c : CRITERIA)
+            if (title.equals(c.title)) return c;
+        return null;
+    }
+
+    private final int index;
+    private final String title;
+    private final int currentCode;
+    private final String keyWords;
+    private final String filter;
+    private final int newPPACode;
+    private final int newCAPCode;
+
+    public Criteria(int index, String title, int currentCode, String keyWords, 
+            String filter, int newPPACode, int newCAPCode) {
+        this.index = index;
+        this.title = title;
+        this.currentCode = currentCode;
+        this.keyWords = keyWords;
+        this.filter = filter;
+        this.newPPACode = newPPACode;
+        this.newCAPCode = newCAPCode;
+    }
+
+    private static final Criteria[] CRITERIA = {
+        new Criteria(0, "Daycare", 5, "daycare or \"child care\" or paternity " 
+                + "or maternity or aftercare", "", 5, 13), 
+        new Criteria(1, "Art", 6, "\" art \" or culture or music or concerts or " 
+                + "history or museum or mural", "", 6, 23), 
+        new Criteria(2, "Real Estate", 12, "\"eminent domain\" or landlord or " 
+                + "\"real estate\" or property or tenant", "", 12, 14), 
+        new Criteria(3, "Lottery", 20, "lottery or lotto", "", 20, 15), 
+        new Criteria(4, "Commemorative", 20, "commemorative or honoring", "", 20, 23), 
+        new Criteria(5, "Local Taxes", 24, "taxes or revenue or assessment or " 
+                + "millage or school or property or budget or bond or debt " 
+                + "or credit", "tax", 24, 1), 
+        new Criteria(6, "Immigration", 5, "immigra or refugee or alien or " 
+                + "border or amnesty or naturalization", "", 9, 9), 
+        new Criteria(7, "Aquaculture", 7, "aquaculture or \"fish farm\"", "", 4, 4)
+    };
+
+    /**
+     * @return the index
+     */
+    public int getIndex() {
+        return index;
+    }
+
+    /**
+     * @return the title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * @return the currentCode
+     */
+    public int getCurrentCode() {
+        return currentCode;
+    }
+
+    /**
+     * @return the keyWords
+     */
+    public String getKeyWords() {
+        return keyWords;
+    }
+
+    /**
+     * @return the filter
+     */
+    public String getFilter() {
+        return filter;
+    }
+
+    /**
+     * @return the newPPACode
+     */
+    public int getNewPPACode() {
+        return newPPACode;
+    }
+
+    /**
+     * @return the newCAPCode
+     */
+    public int getNewCAPCode() {
+        return newCAPCode;
+    }
+
+}

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/AdminController.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/AdminController.java
@@ -67,5 +67,12 @@ public class AdminController {
         Table table = tableLoader.getTableByTableName(tableName);
         return table.updateDataset();
     }
+    
+    @RequestMapping(method = RequestMethod.PUT, value="/assignCAPCode/{tableName}")
+    public ResponseEntity<?> assignCAPCode(@PathVariable String tableName, 
+            @RequestParam(value = "user") User user) {
+        Table table = tableLoader.getTableByTableName(tableName);
+        return table.assignCAPCode();
+    }
 }
 

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/AdminController.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/AdminController.java
@@ -61,11 +61,11 @@ public class AdminController {
         return table.publishDataset();
     }
 
-    @RequestMapping(method = RequestMethod.PUT, value="/update/{tableName}")
+    @RequestMapping(method = RequestMethod.PUT, value="/updateCodes/{tableName}")
     public ResponseEntity<?> update(@PathVariable String tableName, 
             @RequestParam(value = "user") User user) {
         Table table = tableLoader.getTableByTableName(tableName);
-        return table.updateDataset();
+        return table.updateCodes();
     }
     
     @RequestMapping(method = RequestMethod.PUT, value="/assignCAPCode/{tableName}")

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/DocumentController.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/DocumentController.java
@@ -147,6 +147,27 @@ public class DocumentController {
         return new ResponseEntity<>("document code added, bud", HttpStatus.OK);
     }
 
+    @RequestMapping(method = RequestMethod.POST, 
+            value = "/{tableName}/{docid}/batch/{batchid}/update/CAPCode/{codeid}")
+    public ResponseEntity<?> updateCAPCode(@PathVariable String tableName, 
+            @PathVariable String docid, 
+            @PathVariable String batchid, 
+            @PathVariable String codeid, 
+            @RequestParam(value = "user") User user) {
+        int code;
+        try {
+            code = Integer.parseInt(codeid);
+            documentDAO.updateCAPCode(user.getEmail(), tableName, docid, batchid, code);
+        } catch (NumberFormatException nfex) {
+            if (!"null".equals(codeid)) {
+                return new ResponseEntity<>("Bad code value " + codeid, 
+                        HttpStatus.BAD_REQUEST);
+            }
+        }
+        // Either way, this is OK.
+        return new ResponseEntity<>("document code added, bud", HttpStatus.OK);
+    }
+
     @RequestMapping(method = RequestMethod.PUT, value = "/{tableName}")
     @SuppressWarnings("unchecked")
     public ResponseEntity<?> updateDocument(@RequestBody Map<String, Object> docObj, 
@@ -186,6 +207,14 @@ public class DocumentController {
     public ResponseEntity<?> getDocumentClusters(@PathVariable String tableName,
             @PathVariable int batchid, @RequestParam(value = "user") User user) {
         return new ResponseEntity<>(documentDAO.findDocumentsClusters(tableName,
+                batchid, user.getEmail()), HttpStatus.OK);
+    }
+
+    @RequestMapping(method = RequestMethod.GET,
+            value = "/{tableName}/batch/{batchid}/capCodeReview")
+    public ResponseEntity<?> getDocumentCAPCodeReview(@PathVariable String tableName,
+            @PathVariable int batchid, @RequestParam(value = "user") User user) {
+        return new ResponseEntity<>(documentDAO.findDocumentsCAPReview(tableName,
                 batchid, user.getEmail()), HttpStatus.OK);
     }
 

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/IndexController.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/controllers/IndexController.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import static java.util.stream.Collectors.toList;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -74,15 +75,10 @@ public class IndexController extends HttpServlet {
     }
 
     public static List<Table> getEditableTables(TableLoader tableLoader) {
-        List<Table> tables = new ArrayList<>(tableLoader.getTables());
-        Iterator<Table> itr = tables.listIterator();
-        while (itr.hasNext()) {
-            Table table = itr.next();
-            if (!table.isEditable()) {
-                itr.remove();
-            }
-        }
-        return tables;
+        return tableLoader.getTables()
+                .stream()
+                .filter(t->t.isEditable())
+                .collect(toList());
     }
 
 }

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/AssignmentTypeDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/AssignmentTypeDAOImpl.java
@@ -56,7 +56,7 @@ public class AssignmentTypeDAOImpl implements AssignmentTypeDAO {
         CriteriaBuilder builder = session.getCriteriaBuilder();
         CriteriaQuery<AssignmentType> criteria = builder.createQuery(AssignmentType.class);
         criteria.from(AssignmentType.class);
-        List<AssignmentType> listNewsClipTypes = session.createQuery(criteria).getResultList();
-        return listNewsClipTypes;
+        List<AssignmentType> assignmentTypeList = session.createQuery(criteria).getResultList();
+        return assignmentTypeList;
     }
 }

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAO.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAO.java
@@ -66,6 +66,8 @@ public interface DocumentDAO {
 
     public void updateDocumentCode(String email, String tableName, String docid, String batchid, int codeid);
 
+    public void updateCAPCode(String email, String tableName, String docid, String batchid, int codeid);
+
     public List<Map<String,Object>> findDocumentsNoCodes(String tableName, int batchid, String email);
 
     public List<Map<String,Object>> findDocumentsTieBreak(String tableName, int batchid, String email);

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAO.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAO.java
@@ -72,6 +72,8 @@ public interface DocumentDAO {
     
     public List<Map<String, Object>> findDocumentsClusters(String tableName, int batchid, String email);
 
+    public List<Map<String, Object>> findDocumentsCAPReview(String tableName, int batchid, String email);
+
     public void updateDocument(String tableName, Map<String, Object> docObj);
 
     public int insertDocument(String tableName, Map<String, Object> docObj);

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -395,7 +395,7 @@ public class DocumentDAOImpl implements DocumentDAO {
     @Transactional
     public void updateCAPCode(String email, String tableName, String docid, String batchid, int codeid) {
         Session sess = sessionFactory.getCurrentSession();
-        String queryTemplate = "UPDATE %s SET CAPCode=%d, CAPOk=1 WHERE ID=%s";
+        String queryTemplate = "UPDATE %s SET CAPCode=%d, CAPOk=1 WHERE ID='%s'";
         String query = String.format(queryTemplate, tableName, codeid, docid);
         sess.createNativeQuery(query).executeUpdate();
     }

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -147,7 +147,7 @@ public class DocumentDAOImpl implements DocumentDAO {
         String capOKQuery = String.format(capOKQueryTemplate, table.getTableName());
         NativeQuery<Tuple> capCodeQuery = sess.createNativeQuery(capOKQuery, Tuple.class);
         capCodeQuery.stream().forEach(tuple -> {
-            String id = (String) tuple.get("ID");
+            String id = tuple.get("ID").toString();
             statMap.put(id, -2);
         });
         return statMap;
@@ -517,7 +517,15 @@ public class DocumentDAOImpl implements DocumentDAO {
         String selectQueryTemplate = "select ID, %s as Text, %s as Link, %s as Code, CAPCode, CAPOk from "
                 + "(select * from BatchDocument where BatchID=%d) as docs left "
                 + "join %s on DocumentID=ID";
-        String selectQuery = String.format(selectQueryTemplate, textColumn, linkColumn, codeColumn, batchid, tableName);
+        String selectQueryNoLinkTemplate = "select ID, %s as Text, %s as Code, CAPCode, CAPOk from "
+                + "(select * from BatchDocument where BatchID=%d) as docs left "
+                + "join %s on DocumentID=ID";
+        String selectQuery;
+        if (linkColumn != null) {
+            selectQuery = String.format(selectQueryTemplate, textColumn, linkColumn, codeColumn, batchid, tableName);
+        } else {
+            selectQuery = String.format(selectQueryNoLinkTemplate,textColumn,codeColumn, batchid, tableName);
+        }
         try {
         NativeQuery<Tuple> query = sess.createNativeQuery(selectQuery, Tuple.class);
         List<Map<String, Object>> documentsList

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -142,7 +142,7 @@ public class DocumentDAOImpl implements DocumentDAO {
             });
         }
         // Check for CAP Code Review
-        String capOKQueryTemplate = "Select ID CAPOk from %s where isNull(CAPOk) or not CAPOk";
+        String capOKQueryTemplate = "Select ID, CAPOk from %s where isNull(CAPOk) or not CAPOk";
         String capOKQuery = String.format(capOKQueryTemplate, table.getTableName());
         NativeQuery<Tuple> capCodeQuery = sess.createNativeQuery(capOKQuery, Tuple.class);
         capCodeQuery.stream().forEach(tuple -> {

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -389,6 +389,15 @@ public class DocumentDAOImpl implements DocumentDAO {
     public void updateDocumentCode(String email, String tableName, String docid, String batchid, int codeid) {
         updateDocumentFinalCode(tableName, docid, batchid, codeid);
     }
+
+    @Override
+    @Transactional
+    public void updateCAPCode(String email, String tableName, String docid, String batchid, int codeid) {
+        Session sess = sessionFactory.getCurrentSession();
+        String queryTemplate = "UPDATE %s SET CAPCode=%d, CAPOk=1 WHERE ID=%s";
+        String query = String.format(queryTemplate, tableName, codeid, docid);
+        sess.createNativeQuery(query).executeUpdate();
+    }
     
     @Override
     @Transactional

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -497,6 +497,31 @@ public class DocumentDAOImpl implements DocumentDAO {
 
     @Override
     @Transactional
+    public List<Map<String, Object>> findDocumentsCAPReview(String tableName, 
+            int batchid, String email) {
+        Session sess = sessionFactory.getCurrentSession();
+        Table table = tableLoader.getTableByTableName(tableName);
+        String textColumn = table.getTextColumn();
+        String linkColumn = table.getLinkColumn();
+        String codeColumn = table.getCodeColumn();
+        String selectQueryTemplate = "select ID, %s, %s, %s, CAPCode, CAPOk from "
+                + "(select * from BatchDocument where BatchID=%d) as docs left "
+                + "join %s on DocumentID=ID";
+        String selectQuery = String.format(selectQueryTemplate, textColumn, linkColumn, codeColumn, batchid);
+        try {
+        NativeQuery<Tuple> query = sess.createNativeQuery(selectQuery, Tuple.class);
+        List<Map<String, Object>> documentsList
+                = query.stream()
+                        .map(MyTupleToEntityMapTransformer.INSTANCE)
+                        .collect(Collectors.toList());
+        return documentsList;
+        } catch (Throwable ex) {
+            throw new RuntimeException("Error in query " + selectQuery, ex);
+        }
+    }
+
+    @Override
+    @Transactional
     public void updateDocument(String tableName, Map<String, Object> docObj) {
         Session sess = sessionFactory.getCurrentSession();
         String[] keyArray = docObj.keySet().toArray(new String[0]);

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -141,6 +141,14 @@ public class DocumentDAOImpl implements DocumentDAO {
                 statMap.put(id, -1);
             });
         }
+        // Check for CAP Code Review
+        String capOKQueryTemplate = "Select ID CAPOk from %s where isNull(CAPOk) or not CAPOk";
+        String capOKQuery = String.format(capOKQueryTemplate, table.getTableName());
+        NativeQuery<Tuple> capCodeQuery = sess.createNativeQuery(capOKQuery, Tuple.class);
+        capCodeQuery.stream().forEach(tuple -> {
+            String id = (String) tuple.get("ID");
+            statMap.put(id, -2);
+        });
         return statMap;
     }
 

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
@@ -31,6 +31,7 @@
  */
 package edu.temple.cla.policydb.ppdpapp.api.tables;
 
+import edu.temple.cla.policydb.capcodeassignment.AssignCAPCode;
 import edu.temple.cla.policydb.ppdpapp.api.daos.FileDAO;
 import edu.temple.cla.policydb.ppdpapp.api.filters.BinaryFilter;
 import java.util.List;
@@ -1231,8 +1232,10 @@ public abstract class AbstractTable implements Table {
     @Override
     public ResponseEntity<?> assignCAPCode() {
         if (isMajorOnly()) {
-            // call CAPCodeAssignment
-            return new ResponseEntity<>("Not Implemented", HttpStatus.NOT_IMPLEMENTED);
+            AssignCAPCode assignCAPCode = new AssignCAPCode();
+            assignCAPCode.setDataSource(datasource);
+            assignCAPCode.setSessionFactory(sessionFactory);
+            return assignCAPCode.doAssignment(this);
         }
         String assignCAPCodeTemplate = "update %s left join PPAtoCAP on "
                 + "%s.%s=PPAtoCAP.PPACode set %s.CAPCode=PPAtoCAP.CAPCode "

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
@@ -1218,6 +1218,11 @@ public abstract class AbstractTable implements Table {
         return new ResponseEntity<>(documentName + " has been updated "
                 + numberChanged + " rows matched", HttpStatus.OK);
     }
+    
+    @Override
+    public ResponseEntity<?> assignCAPCode() {
+        return new ResponseEntity<>("Not Implemented", HttpStatus.NOT_IMPLEMENTED);
+    }
 
     @Override
     public void setSessionFactory(SessionFactory sessionFactory) {

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/Table.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/Table.java
@@ -338,6 +338,8 @@ public interface Table {
     
     ResponseEntity<?> updateDataset();
     
+    ResponseEntity<?> assignCAPCode();
+    
     void setSessionFactory(SessionFactory sessionFactory);
     
     String getFileUploadHtml();

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/Table.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/Table.java
@@ -336,7 +336,7 @@ public interface Table {
     
     ResponseEntity<?> publishDataset();
     
-    ResponseEntity<?> updateDataset();
+    ResponseEntity<?> updateCodes();
     
     ResponseEntity<?> assignCAPCode();
     

--- a/src/main/webapp/app/admin/admin.html
+++ b/src/main/webapp/app/admin/admin.html
@@ -58,6 +58,12 @@ POSSIBILITY OF SUCH DAMAGE.
             <i ng-show="processing" class="fa fa-spinner fa-spin"></i>
         </button>
     </div>
+    <div class="form-group margin-top-xlarge">
+        <button type="button" class="btn btn-primary" ng-click="doAssignCAPCode()" ng-disabled="form.$invalid || processing || !dataset_type">
+            Assign CAP Codes
+            <i ng-show="processing" class="fa fa-spinner fa-spin"></i>
+        </button>
+    </div>
         <div ng-show="success" class="row margin-top-medium"><div class="col-md-4 col-md-push-4">
                 <alert type="success" close="closeAlert()"> {{success}}</alert>
             </div></div>

--- a/src/main/webapp/app/admin/adminControllers.js
+++ b/src/main/webapp/app/admin/adminControllers.js
@@ -76,6 +76,20 @@ admin.controller('adminCtrl', ['$scope', '$location', 'adminAPI', 'tablesAPI', '
                                 $scope.processing = false;                             
                             });
                 };
+                $scope.doAssignCAPCode = function() {
+                    $scope.pricessing = true;
+                    $scope.error = false;
+                    $scope.success = false;
+                    adminAPI.assignCAPCode(authInfo.token, $scope.dataset_type.TableName)
+                            .success(function (res) {
+                                $scope.processing = false;
+                                $scope.success = res;
+                            })
+                            .error(function (err) {
+                                $scope.error = err;
+                                $scope.processing = false;                             
+                            });
+                };
     }]);
 
 

--- a/src/main/webapp/app/admin/adminControllers.js
+++ b/src/main/webapp/app/admin/adminControllers.js
@@ -66,7 +66,7 @@ admin.controller('adminCtrl', ['$scope', '$location', 'adminAPI', 'tablesAPI', '
                     $scope.pricessing = true;
                     $scope.error = false;
                     $scope.success = false;
-                    adminAPI.update(authInfo.token, $scope.dataset_type.TableName)
+                    adminAPI.updateCodes(authInfo.token, $scope.dataset_type.TableName)
                             .success(function (res) {
                                 $scope.processing = false;
                                 $scope.success = res;

--- a/src/main/webapp/app/admin/adminFactory.js
+++ b/src/main/webapp/app/admin/adminFactory.js
@@ -43,6 +43,10 @@ admin.factory('adminAPI', ['$http', 'apiRoot', function ($http, apiRoot) {
             return $http.put(urlBase + 'update/' + dataset + '?token=' + token);
         };
 
+        dataFactory.assignCAPCode = function(token, dataset) {
+            return $http.put(urlBase + 'assignCAPCode/' + dataset + '?token=' + token);
+        };
+
         return dataFactory;
     }]);
 

--- a/src/main/webapp/app/admin/adminFactory.js
+++ b/src/main/webapp/app/admin/adminFactory.js
@@ -39,8 +39,8 @@ admin.factory('adminAPI', ['$http', 'apiRoot', function ($http, apiRoot) {
             return $http.put(urlBase + 'publish/' + dataset + '?token=' + token);
         };
 
-        dataFactory.update = function(token, dataset) {
-            return $http.put(urlBase + 'update/' + dataset + '?token=' + token);
+        dataFactory.updateCodes = function(token, dataset) {
+            return $http.put(urlBase + 'updateCodes/' + dataset + '?token=' + token);
         };
 
         dataFactory.assignCAPCode = function(token, dataset) {

--- a/src/main/webapp/app/assignments/assignments.js
+++ b/src/main/webapp/app/assignments/assignments.js
@@ -45,6 +45,16 @@ acct.config(['$routeProvider', function ($routeProvider) {
            }
         });
 
+        $routeProvider.when('/assignments/:batch_id/cap_code_review/${tableName}', {
+           templateUrl: 'app/documents/${document}/${document}_cap_code_review.html',
+           caseInsensitiveMatch: true,
+           controller: '${document}CAPCodeReviewCtrl',
+           resolve: {
+               authenticated: function (authFactory) {
+                   return authFactory.resolveIsLoggedIn();
+               }
+           }
+        });
         $endFor
             
     }]);

--- a/src/main/webapp/app/assignments/assignmentsControllers.js
+++ b/src/main/webapp/app/assignments/assignmentsControllers.js
@@ -44,10 +44,15 @@ acct.controller('assignmentsCtrl', ['$scope', '$location', 'assignmentsAPI', 'ta
                             .success(function (res) {
                                 $location.path('/assignments/' + batchObj.batchID + '/tiebreak/' + res.TableName);
                             });
-                } else if (batchObj.assignmentTypeID ===5) {
+                } else if (batchObj.assignmentTypeID === 5) {
                     tablesAPI.find(authInfo.token, batchObj.tablesID)
                             .success(function (res) {
                                 $location.path('/assignments/' + batchObj.batchID + '/cluster_resolution/' + res.TableName);
+                            });     
+                } else if (batchObj.assignmentTypeID === 6) {
+                    tablesAPI.find(authInfo.token, batchObj.tablesID)
+                            .success(function (res) {
+                                $location.path('/assignments/' + batchObj.batchID + '/cap_code_review/' + res.TableName);
                             });     
                 } else {
                     tablesAPI.find(authInfo.token, batchObj.tablesID)

--- a/src/main/webapp/app/documents/prototypes/documentControllers.js
+++ b/src/main/webapp/app/documents/prototypes/documentControllers.js
@@ -449,7 +449,7 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                         $scope.processing = true;
                         $scope.editedRows.forEach(function (row) {
                         if (typeof row !== 'undefined' && typeof row.UserCode !== 'undefined') {
-                        promises.push(${document}API.updateCode(authInfo.token, row.ID, row.UserCode));
+                        promises.push(${document}API.updateCAPCode(authInfo.token, row.ID, row.UserCode));
                         }
                         });
                         $q.all(promises).then(function () {
@@ -458,8 +458,8 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                 });
                 };
                 $scope.codeDoc = function (row) {
-                    if (typeof row.UserCode !== 'undefined') {
-                        ${document}API.updateCode(authInfo.token, row.ID, $routeParams.batch_id, row.UserCode)
+                    if (typeof row.CAPCode !== 'undefined') {
+                        ${document}API.updateCAPCode(authInfo.token, row.ID, $routeParams.batch_id, row.CAPCode)
                                 .error(function(res) {
                                     alert('Error updating database\n' + res + '\nSee log');
                                 });

--- a/src/main/webapp/app/documents/prototypes/documentControllers.js
+++ b/src/main/webapp/app/documents/prototypes/documentControllers.js
@@ -415,7 +415,7 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                     console.log("reloadBatchDocs called");
                 $scope.loaded = false;
                         $scope.requestFailed = false;
-                        ${document}API.clusterResolution(authInfo.token, $routeParams.batch_id)
+                        ${document}API.capCodeReview(authInfo.token, $routeParams.batch_id)
                         .success(function (res) {
                         $scope.gridOptions.data = res;
                                 $scope.loaded = true;

--- a/src/main/webapp/app/documents/prototypes/documentControllers.js
+++ b/src/main/webapp/app/documents/prototypes/documentControllers.js
@@ -21,7 +21,7 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                 ${document}API.getAll(authInfo.token)
                         .success(function (res) {
                         for (i = 0; i < res.length; i++) {
-                        if (res[i].${codeColumn} !== null && res[i].stat !== -1) {
+                        if (res[i].${codeColumn} !== null && res[i].stat !== -1 && res[i].stat !== -2) {
                         res[i].Status = "complete";
                         } else if (res[i].stat === 0) {
                         res[i].Status = "needs first code";
@@ -30,7 +30,9 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                         } else if (res[i].stat === 2) {
                         res[i].Status = "needs tie break";
                         } else if (res[i].stat === -1) {
-                        res[i].Status = "needs cluster resolution"
+                        res[i].Status = "needs cluster resolution";
+                        } else if (res[i].stat === -2) {
+                            res[i].Status = "needs CAP Code review";
                         }
                         }
                         $scope.grid${documentUC}.data = res;
@@ -86,7 +88,7 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                                 ${document}API.noBatch(authInfo.token, assignment_type, batch_id)
                                 .success(function (res) {
                                 for (i = 0; i < res.length; i++) {
-                                if (res[i].Code !== null  && res[i].stat !== -1) {
+                                if (res[i].Code !== null  && res[i].stat !== -1 && res[i].stat !== -2) {
                                 res[i].Status = "complete";
                                 } else if (res[i].stat === 0) {
                                 res[i].Status = "needs first code";
@@ -95,7 +97,9 @@ ${document}.controller('${document}Ctrl', ['$scope', '$routeParams', '$q', '$loc
                                 } else if (res[i].stat === 2) {
                                 res[i].Status = "need tie break";
                                 } else if (res[i].stat === -1) {
-                                res[i].Status = "needs cluster resolution"
+                                res[i].Status = "needs cluster resolution";
+                                } else if (res[i].stat === -2) {
+                                    res[i].Status = "needs CAP Code review";
                                 }
                                 }
                                 $scope.grid${documentUC}.data = res;

--- a/src/main/webapp/app/documents/prototypes/documentFactory.js
+++ b/src/main/webapp/app/documents/prototypes/documentFactory.js
@@ -56,7 +56,7 @@ ${document}.factory('${document}API', ['$http', '$upload', 'apiRoot', function (
             return $http.get(urlBase + '/batch/' + batch_id + '/capCodeReview?token=' + token);
         };
         dataFactory.updateCAPCode = function (token, doc_id, batch_id, code_id) {
-            return $http.post(urlBase + '/' + doc_id + '/batch/' + batch_id + '/update/capCode/' + code_id + '?token=' + token);
+            return $http.post(urlBase + '/' + doc_id + '/batch/' + batch_id + '/update/CAPCode/' + code_id + '?token=' + token);
         };
         
         return dataFactory;

--- a/src/main/webapp/app/documents/prototypes/documentFactory.js
+++ b/src/main/webapp/app/documents/prototypes/documentFactory.js
@@ -52,6 +52,12 @@ ${document}.factory('${document}API', ['$http', '$upload', 'apiRoot', function (
         dataFactory.updateCode = function (token, doc_id, batch_id, code_id) {
             return $http.post(urlBase + '/' + doc_id + '/batch/' + batch_id + '/update/code/' + code_id + '?token=' + token);
         };
+        dataFactory.capCodeReview = function (token, batch_id) {
+            return $http.get(urlBase + '/batch/' + batch_id + '/capCodeReview?token=' + token);
+        };
+        dataFactory.updateCAPCode = function (token, doc_id, batch_id, code_id) {
+            return $http.post(urlBase + '/' + doc_id + '/batch/' + batch_id + '/update/capCode/' + code_id + '?token=' + token);
+        };
         
         return dataFactory;
     }]);

--- a/src/main/webapp/app/documents/prototypes/document_cap_code_review.html
+++ b/src/main/webapp/app/documents/prototypes/document_cap_code_review.html
@@ -11,7 +11,8 @@
                 <th>ID</th>
                 <th>Text</th>
                 <th>Code</th>
-                <th>Final Code</th>
+                <th>CAP Code</th>
+                <th>CAP OK</th>
             </tr>
             </thead>
             <tbody>
@@ -19,9 +20,12 @@
                 <td style="background-color:{{row.bgColor}}" ng-bind-html="row.IDLink"></td>
                 <td style="background-color:{{row.bgColor}}" ng-bind-html="row.Text"></td>
                 <td style="background-color:{{row.bgColor}}">{{row.Code}}</td>
-                <td style="background-color:{{row.bgColor}}"><input type="text" ng-model="row.UserCode"
+                <td style="background-color:{{row.bgColor}}"><input type="text" ng-model="row.CAPCode"
                     ng-model-options="{updateOn: 'blur'}"
                     ng-blur="codeDoc(row)"/></td>
+                <td style="background-color:{{row.bgColor}}"><input type="checkbox" ng-model="row.CAPOk"
+                    ng-model-options="{updateOn: 'blur'}"
+                    ng-blur="codeDoc(row)"/></td>               
             </tr>
             </tbody>
         </table>

--- a/src/main/webapp/app/documents/prototypes/document_cap_code_review.html
+++ b/src/main/webapp/app/documents/prototypes/document_cap_code_review.html
@@ -1,0 +1,38 @@
+<div ng-class="{transparent: !loaded}">
+    <div class="grid-heading">${document}</div>
+    <div class="grid-buttons">
+        <div class="grid-button" ng-show="process_action" ng-click="codeDocs()" ng-class="{disabled: processing}"><i class="fa fa-plus"></i> Add Codes</div>
+        <div class="grid-button" ng-click="reloadBatchDocs()" title="Refresh the list"><i class="fa fa-refresh"></i></div>
+    </div>
+    <div class="grid">
+        <table border="1">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Text</th>
+                <th>Code</th>
+                <th>Final Code</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr ng-repeat="row in gridOptions.data">
+                <td style="background-color:{{row.bgColor}}" ng-bind-html="row.IDLink"></td>
+                <td style="background-color:{{row.bgColor}}" ng-bind-html="row.Text"></td>
+                <td style="background-color:{{row.bgColor}}">{{row.Code}}</td>
+                <td style="background-color:{{row.bgColor}}"><input type="text" ng-model="row.UserCode"
+                    ng-model-options="{updateOn: 'blur'}"
+                    ng-blur="codeDoc(row)"/></td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<div class="connection-problem" ng-class="{concealed: !requestFailed}">
+    <i class="fa fa-warning"></i>
+    <div class="message">Server Error.</div>
+</div>
+<div class="loading-animation" ng-class="{concealed: (loaded || requestFailed)}">
+    <div class="loading-animation-bg">
+        <i class="fa fa-refresh"></i>
+    </div>
+</div>

--- a/src/test/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCodeTest.java
+++ b/src/test/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCodeTest.java
@@ -74,12 +74,12 @@ public class AssignCAPCodeTest {
 
         @Override
         public int getId() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setId(int id) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
@@ -89,87 +89,87 @@ public class AssignCAPCodeTest {
 
         @Override
         public void setTableName(String tableName) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public boolean isCode3() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getTableTitle() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setTableTitle(String tableTitle) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public boolean isMajorOnly() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setMajorOnly(boolean majorOnly) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public int getMinYear() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setMinYear(int minYear) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public int getMaxYear() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setMaxYear(int maxYear) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public List<Filter> getFilterList() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public int getFilterListSize() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setFilterList(List<Filter> filterList) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public List<MetaData> getMetaDataList() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setMetaDataList(List<MetaData> metaDataList) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public char getQualifier() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setQualifier(char qualifier) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
@@ -179,17 +179,17 @@ public class AssignCAPCodeTest {
 
         @Override
         public void setTextColumn(String textColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getLinkColumn() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setLinkColumn(String linkColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
@@ -199,192 +199,192 @@ public class AssignCAPCodeTest {
 
         @Override
         public void setCodeColumn(String codeColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getDateColumn() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDateColumn(String dateColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getDateFormat() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDateFormat(String dateFormat) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported."); 
         }
 
         @Override
         public String getYearColumn() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setYearColumn(String yearColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String[] getDrillDownColumns() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDrillDownColumns(String[] drillDownColumns) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String[] getCodingColumns() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getCodingColumnsList() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setCodingColumns(String[] codingColumns) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setNoteColumn(String noteColumn) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getNoteColumn() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public boolean isDataEntry() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDataEntry(boolean isDataEntry) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public boolean isEditable() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setEditable(boolean isEditable) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public boolean isRequired() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setRequired(boolean isRequired) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public Set<String> getColumns() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setColumns(Collection<String> columns) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getDocumentName() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDocumentName(String documentName) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public int getNumCodesRequired() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setNumCodesRequired(int numCodesRequired) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public Map<String, String> getTemplateParameters() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public ResponseEntity<?> uploadFile(String docObjJson, MultipartFile file) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public ResponseEntity<?> uploadFile(FileDAO fileDAO, MultipartFile file) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public ResponseEntity<?> publishDataset() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
-        public ResponseEntity<?> updateDataset() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        public ResponseEntity<?> updateCodes() {
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public ResponseEntity<?> assignCAPCode() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setSessionFactory(SessionFactory sessionFactory) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getFileUploadHtml() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public String getFileUploadJavaScript() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public SessionFactory getSessionFactory() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public void setDataSource(DataSource datasource) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
 
         @Override
         public DataSource getDataSource() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported.");
         }
     }
     

--- a/src/test/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCodeTest.java
+++ b/src/test/java/edu/temple/cla/policydb/capcodeassignment/AssignCAPCodeTest.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2019, Temple University
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ * * All advertising materials features or use of this software must display 
+ *   the following  acknowledgement
+ *   This product includes software developed by Temple University
+ * * Neither the name of the copyright holder nor the names of its 
+ *   contributors may be used to endorse or promote products derived 
+ *   from this software without specific prior written permission. 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.temple.cla.policydb.capcodeassignment;
+
+import edu.temple.cla.policydb.ppdpapp.api.daos.FileDAO;
+import edu.temple.cla.policydb.ppdpapp.api.filters.Filter;
+import edu.temple.cla.policydb.ppdpapp.api.models.MetaData;
+import edu.temple.cla.policydb.ppdpapp.api.tables.Table;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.hibernate.SessionFactory;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ *
+ * @author Paul
+ */
+public class AssignCAPCodeTest {
+    
+    public AssignCAPCodeTest() {
+    }
+
+
+    /**
+     * Test of createQuery method, of class AssignCAPCode.
+     */
+    @Test
+    public void testCreateQuery() {
+        Table table = new TestTable();
+        Criteria criteria = new Criteria(5, "Local Taxes", 24, "taxes or revenue" 
+                , "tax", 24, 1); 
+        String expected = "UPDATE NewsClips SET CAPCode=1, CAPOk=0 WHERE "
+                + "Code=24 AND (Abstract LIKE('%taxes%') OR Abstract LIKE('%revenue%')) AND tax<>0";
+        String actual = AssignCAPCode.createQuery(criteria, table);
+        assertEquals(expected, actual); 
+    }
+    
+    private static class TestTable implements Table {
+
+        @Override
+        public int getId() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setId(int id) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getTableName() {
+            return "NewsClips";
+        }
+
+        @Override
+        public void setTableName(String tableName) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isCode3() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getTableTitle() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setTableTitle(String tableTitle) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isMajorOnly() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setMajorOnly(boolean majorOnly) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getMinYear() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setMinYear(int minYear) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getMaxYear() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setMaxYear(int maxYear) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public List<Filter> getFilterList() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getFilterListSize() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setFilterList(List<Filter> filterList) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public List<MetaData> getMetaDataList() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setMetaDataList(List<MetaData> metaDataList) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public char getQualifier() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setQualifier(char qualifier) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getTextColumn() {
+            return "Abstract";
+        }
+
+        @Override
+        public void setTextColumn(String textColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getLinkColumn() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setLinkColumn(String linkColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getCodeColumn() {
+            return "Code";
+        }
+
+        @Override
+        public void setCodeColumn(String codeColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getDateColumn() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDateColumn(String dateColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getDateFormat() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDateFormat(String dateFormat) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getYearColumn() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setYearColumn(String yearColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String[] getDrillDownColumns() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDrillDownColumns(String[] drillDownColumns) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String[] getCodingColumns() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getCodingColumnsList() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setCodingColumns(String[] codingColumns) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setNoteColumn(String noteColumn) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getNoteColumn() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isDataEntry() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDataEntry(boolean isDataEntry) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isEditable() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setEditable(boolean isEditable) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setRequired(boolean isRequired) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Set<String> getColumns() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setColumns(Collection<String> columns) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getDocumentName() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDocumentName(String documentName) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getNumCodesRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setNumCodesRequired(int numCodesRequired) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Map<String, String> getTemplateParameters() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ResponseEntity<?> uploadFile(String docObjJson, MultipartFile file) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ResponseEntity<?> uploadFile(FileDAO fileDAO, MultipartFile file) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ResponseEntity<?> publishDataset() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ResponseEntity<?> updateDataset() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ResponseEntity<?> assignCAPCode() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setSessionFactory(SessionFactory sessionFactory) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getFileUploadHtml() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public String getFileUploadJavaScript() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public SessionFactory getSessionFactory() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setDataSource(DataSource datasource) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public DataSource getDataSource() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+    }
+    
+}


### PR DESCRIPTION
This pull request adds the function to assign CAPCodes to each of the tables. For tables with only Major-Only codes, the assignment sets the CAPCode equal to the Code but then applies key-word criteria to assign a different CAPCode. These are then flagged for manual review. For the other tables, the crosswalk table PPAtoCAP gives the code mappings. Rows for which previous assignment of CAPCode differs from the crosswalk are flagged for manual review.