### PR TITLE
Minor: changed matches from Integer to int. Removed Logging no longer…

### DIFF
--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/daos/DocumentDAOImpl.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import javax.persistence.Tuple;
+import org.apache.log4j.Logger;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.Session;
@@ -56,6 +57,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 public class DocumentDAOImpl implements DocumentDAO {
+    
+    private final static Logger LOGGER = Logger.getLogger(DocumentDAOImpl.class);
 
     @Autowired
     private final SessionFactory sessionFactory;
@@ -369,7 +372,7 @@ public class DocumentDAOImpl implements DocumentDAO {
         List<Integer> userPolicyCodes = query.stream()
                 .map(tuple -> (Integer) tuple.get("Code"))
                 .collect(Collectors.toList());
-        Integer matches = 1;
+        int matches = 1;
         if (userPolicyCodes.size() >= maxNumOfCodes) { // This is a tiebreak
             insertUserPolicyCode(email, tableName, docid, batchid, codeid);
             updateDocumentFinalCode(tableName, docid, batchid, codeid);

--- a/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
+++ b/src/main/java/edu/temple/cla/policydb/ppdpapp/api/tables/AbstractTable.java
@@ -718,7 +718,6 @@ public abstract class AbstractTable implements Table {
                         stb.append(" />\n");
                     }
                 } else if (metaData.isUrl()) {
-                    LOGGER.info("before" + columnName);
                     if (columnName.charAt(0) == '#') {
                         int len = columnName.length();
                         if (columnName.charAt(len-1) == '#') {
@@ -726,7 +725,6 @@ public abstract class AbstractTable implements Table {
                         }
                         columnName = columnName.substring(1, len-1);
                     }
-                    LOGGER.info("after" + columnName);
                     stb.append("<a href=\"{{")
                             .append(columnName)
                             .append("}}\">{{")


### PR DESCRIPTION
Problem reported that some records were being flagged as needing tiebreak when all codes matched.
Attempting to reproduce problem. Made minor change and added logging. Problem not reproduced.
